### PR TITLE
Rename to pano-js, to enable use with yarn link

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "license": "UNLICENSED",
-  "name": "pano-monorepo",
+  "name": "pano-js",
   "version": "1.0.0",
   "repository": "git@github.com:techvalidate/pano-js.git",
   "contributors": [

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@pano/frontend",
+  "name": "pano-js/frontend",
   "version": "1.0.0",
   "repository": "git@github.com:techvalidate/pano.git",
   "contributors": [

--- a/packages/legacy/package.json
+++ b/packages/legacy/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@pano/legacy",
+  "name": "pano-js/legacy",
   "version": "1.0.0",
   "repository": "git@github.com:techvalidate/pano.git",
   "contributors": [


### PR DESCRIPTION
Rename the pano-js project, because special characters in names are not allowed when using yarn link.